### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 面试鸭
 
+[![Listed on TakoAPI](https://takoapi.com/api/badge/liyupi-mianshiya)](https://takoapi.com/agents/liyupi-mianshiya)
+
 ![](https://img.shields.io/badge/React-%5E17.0.0-brightgreen)
 ![](https://img.shields.io/badge/Express-%5E4.17.2-yellow)
 


### PR DESCRIPTION
Hi! 👋 **mianshiya** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/liyupi-mianshiya

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building mianshiya! 🙏